### PR TITLE
[CRB-141] Add link to official .NET installation instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Command-line client for the Creditcoin blockchain.
 The Creditcoin Client docker images are available on [Docker Hub](https://hub.docker.com/r/gluwa/creditcoin-client).
 
 # Build and Test
+
+Prerequisite: dotnet-sdk-3.1. See
+[Install the .NET SDK or the .NET Runtime on Ubuntu](https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu)
+for more details.
+
 ```
 dotnet restore
 dotnet build

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ The Creditcoin Client docker images are available on [Docker Hub](https://hub.do
 
 # Build and Test
 
-Prerequisite: dotnet-sdk-3.1. See
+Prerequisite: dotnet-sdk-3.1.
+* Windows - See [Install .NET on Windows](https://docs.microsoft.com/en-us/dotnet/core/install/windows?tabs=netcore31) for more details.
+* Ubuntu - See
 [Install the .NET SDK or the .NET Runtime on Ubuntu](https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu)
 for more details.
+* For other OS options, see [Install .NET on Windows, Linux, and macOS](https://docs.microsoft.com/en-us/dotnet/core/install/)
 
 ```
 dotnet restore


### PR DESCRIPTION
Other than the missing instruction on how to install dotnet on Linux the rest of the instructions worked without an issue for me.