### PR TITLE
[CRB-146] Quality of life improvements

### DIFF
--- a/ccclient/Program.cs
+++ b/ccclient/Program.cs
@@ -171,6 +171,7 @@ namespace ccclient
             string creditcoinRestApiURL = config["creditcoinRestApiURL"];
             string creditcoinUrl = string.IsNullOrWhiteSpace(creditcoinRestApiURL) ? "http://localhost:8008" : creditcoinRestApiURL;
             HttpClient httpClient = new HttpClient();
+            httpClient.Timeout = TimeSpan.FromMinutes(10);
 
             string progressToken = null;
             string pluginProgress = Path.Combine(pluginFolder, $"plugin_progress{progressId}.txt");

--- a/ccclient/ccclient.csproj
+++ b/ccclient/ccclient.csproj
@@ -38,6 +38,10 @@
     <MakeDir Directories="$(OutDir)plugins" />
   </Target>
 
+  <Target Name="MakeMyDir" AfterTargets="Publish">
+    <MakeDir Directories="$(OutDir)plugins" />
+  </Target>
+
   <ItemGroup>
     <MySourceFiles Include="$(OutDir)cbitcoin.dll;$(OutDir)cccore.dll;$(OutDir)ccplugin.dll;$(OutDir)cerc20.dll;$(OutDir)cethereum.dll;$(OutDir)cethless.dll" />
   </ItemGroup>
@@ -45,5 +49,9 @@
   <Target Name="CopyFiles" AfterTargets="Build">
     <Copy SourceFiles="@(MySourceFiles)" DestinationFolder="$(OutDir)plugins" />
   </Target>
-  
+
+  <Target Name="CopyFiles" AfterTargets="Publish">
+    <Copy SourceFiles="@(MySourceFiles)" DestinationFolder="$(PublishDir)plugins" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
1. Copy plugins to `plugins` subdirectory when `dotnet publish` command is used to generate binaries - Saves needing to manually copy them into the folder for local builds.
2. Increase timeout to 10 minutes to prevent the application from timing out prior to command completion.